### PR TITLE
Add missing comma in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,6 @@ Imports:
 RdMacros:
     Rdpack
 Remotes:
-    pmcharrison/psychTestR
+    pmcharrison/psychTestR,
     klausfrieler/shinyRadioMatrix
 RoxygenNote: 7.1.1


### PR DESCRIPTION
Missing comma in Remotes causes an error in `remotes::install_github('klausfrieler/GAR')`, so `GAR` cannot be installed.